### PR TITLE
Export `observeResize`

### DIFF
--- a/addon/modifiers/observe-resize.js
+++ b/addon/modifiers/observe-resize.js
@@ -6,7 +6,7 @@ const observerMap = new WeakMap();
  * @param {Element} [element] The DOM element this modifier is applied to
  * @param {[Function]} [params] Positional modifier params
  */
-function observeResize(element, [changeHandler]) {
+export function observeResize(element, [changeHandler]) {
   let observer;
 
   if (observerMap.has(changeHandler)) {


### PR DESCRIPTION
Hi! Thanks for the awesome modifier!

I'm planning a major upgrade of my [ember-element-query](https://github.com/lolmaus/ember-element-query) addon. Here's a [readme](https://github.com/lolmaus/ember-element-query/tree/gen-4#ember-element-query) for a version that does not exist yet.

I would like my addon to offer a modifier that uses `ResizeObserver` on the element and does a lot of stuff, including caching previous results.

I've figured that if I was able to import `observeResize` from your addon, I could call it in my modifier instead of copy-pasting `observerResize` code into my addon.